### PR TITLE
Add always-embed feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "include_dir_as_map"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "proc_include_dir_as_map",
 ]
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "proc_include_dir_as_map"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ license = "MIT"
 [dependencies]
 proc_include_dir_as_map = { version = "1", path = "proc" }
 
+[features]
+always-embed = [ "proc_include_dir_as_map/always-embed" ]
+
 [workspace]
 members = [
   "proc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "include_dir_as_map"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = [ "fboulnois <fboulnois@users.noreply.github.com>" ]
 description = "Embed files from a directory as a hashmap in the rust binary"

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # include_dir_as_map
 
-A procedural macro which embeds files from a directory as a hashmap in the rust
-binary. This can be used to embed assets such as images, html, css, and js.
+A procedural macro which embeds files from a directory into the rust binary as
+a hashmap. This can be used to embed assets such as images, html, css, and js.
 
 `include_dir_as_map` extends `include_str!()` and `include_bytes!()` and is
 similar to [`include_dir`](https://github.com/Michael-F-Bryan/include_dir).
 
 ## Usage
-
-### Quickstart
 
 Include the following section in `Cargo.toml`:
 
@@ -19,10 +17,11 @@ include_dir_as_map="1"
 
 In your rust code, include the following:
 
-```rust
-// DirMap is simply an alias for HashMap<String, Vec<u8>>
+```rust ignore
+// DirMap is an alias for HashMap<String, Vec<u8>>
 use include_dir_as_map::{include_dir_as_map, DirMap};
 
+// Environment variables will be expanded at compile time
 let dirmap: DirMap = include_dir_as_map!("$CARGO_MANIFEST_DIR");
 let bytes = dirmap.get("Cargo.toml")?;
 ```
@@ -31,7 +30,18 @@ All paths are relative to the embedded directory, so if `root` contains files
 `root/foo.txt` and `root/next/bar.txt`, then `include_dir_as_map!("root")` will
 result in a hashmap with keys `foo.txt` and `next/bar.txt`.
 
-### Examples
+## Features
+
+By default, the files are read from the filesystem at runtime in debug mode for
+compilation speed. To override this behavior, enable the `always-embed` feature
+in `Cargo.toml`:
+
+```toml
+[dependencies]
+include_dir_as_map={ version="1", features=[ "always-embed" ] }
+```
+
+## Examples
 
 See the `examples/` directory for more examples:
 

--- a/proc/Cargo.toml
+++ b/proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proc_include_dir_as_map"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = [ "fboulnois <fboulnois@users.noreply.github.com>" ]
 description = "Magic which implements the procedural macro `include_dir_as_map`"

--- a/proc/Cargo.toml
+++ b/proc/Cargo.toml
@@ -13,3 +13,6 @@ proc-macro = true
 [dependencies]
 quote = "1"
 proc-macro2 = "1"
+
+[features]
+always-embed = []

--- a/proc/src/lib.rs
+++ b/proc/src/lib.rs
@@ -141,6 +141,34 @@ fn internal_dir_as_map(input: TokenStream) -> TokenStream {
     output.into()
 }
 
+/// The procedural macro magic that embeds files from a directory into the rust
+/// binary as a hashmap.
+///
+/// The input must be a string literal that represents the directory to embed.
+/// This string can contain environment variables which will be expanded at
+/// compile time.
+///
+/// The output is a `DirMap` which is an alias for `HashMap<String, Vec<u8>>`.
+/// This hashmap maps the relative path of each file to its contents as a vector
+/// of bytes.
+///
+/// By default, the files are read from the filesystem at runtime in debug mode
+/// for compilation speed. To override this behavior, enable the `always-embed`
+/// feature in `Cargo.toml`.
+///
+/// # Panics
+///
+/// This function will panic if the directory does not exist or if any file in
+/// the directory cannot be read.
+///
+/// # Examples
+///
+/// ```ignore
+/// use include_dir_as_map::{include_dir_as_map, DirMap};
+///
+/// let dirmap: DirMap = include_dir_as_map!("$CARGO_MANIFEST_DIR");
+/// let bytes = dirmap.get("Cargo.toml")?;
+/// ```
 #[proc_macro]
 pub fn include_dir_as_map(input: TokenStream) -> TokenStream {
     internal_dir_as_map(input)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,12 @@
 #![forbid(unsafe_code)]
 
+#![doc = include_str!("../README.md")]
+
 use std::collections::HashMap;
 
 pub use proc_include_dir_as_map::include_dir_as_map;
 
+/// Maps the relative path of each file to its contents as a vector of bytes.
 pub type DirMap = HashMap<String, Vec<u8>>;
 
 #[cfg(test)]


### PR DESCRIPTION
By default, files are now read from the filesystem at runtime in debug mode for compilation speed. To override this behavior, enable the `always-embed` feature in `Cargo.toml`:

```toml
[dependencies]
include_dir_as_map={ version="1", features=[ "always-embed" ] }
```